### PR TITLE
push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ frontend.pid
 
 # Node modules in tests directory
 /tests/node_modules/
+/.vs/bug-tracker/CopilotIndices/17.14.1561.44479/CodeChunks.db
+/.vs/bug-tracker/CopilotIndices/17.14.1561.44479/CodeChunks.db-shm
+/.vs/bug-tracker/CopilotIndices/17.14.1561.44479/CodeChunks.db-wal
+/.vs/bug-tracker/CopilotIndices/17.14.1561.44479/SemanticSymbols.db
+/.vs/bug-tracker/CopilotIndices/17.14.1561.44479/SemanticSymbols.db-shm
+/.vs/bug-tracker/CopilotIndices/17.14.1561.44479/SemanticSymbols.db-wal


### PR DESCRIPTION
Ignore VS CopilotIndices database files in .gitignore

Added .vs/bug-tracker/CopilotIndices/17.14.1561.44479/ database and index files to .gitignore to prevent tracking of IDE-generated files such as CodeChunks.db and SemanticSymbols.db. This helps keep the repository clean from local development artifacts.